### PR TITLE
Support multiple venvs in Makefile

### DIFF
--- a/docs/work.md
+++ b/docs/work.md
@@ -232,9 +232,18 @@ make setup
 This will install the project's dependencies in `__pypackages__`:
 one folder per chosen Python version.
 The chosen Python versions are defined in the Makefile.
+If you would like to use *virutalenvs* instead, uncomment this line in the Makefile:
+
+```bash
+export PDM_MULTIRUN_USE_VENVS = 1 # Uncomment this line to enable venvs when using multirun
+```
+
+With this option, the `scripts/setup.sh` script 
+will create named venvs (`name=3.xx`) 
+in your `venv.location` location (from pdm).
 
 If you don't have the `make` command,
-you can use `bash scripts/setup.sh` instead,
+you can use `bash scripts/setup.sh` directly,
 or even just `pdm install`
 if you don't plan on using multiple Python versions.
 

--- a/docs/work.md
+++ b/docs/work.md
@@ -229,23 +229,25 @@ The first thing you should run when entering your repository is:
 make setup
 ```
 
-This will install the project's dependencies in `__pypackages__`:
-one folder per chosen Python version.
-The chosen Python versions are defined in the Makefile.
-If you would like to use *virutalenvs* instead, uncomment this line in the Makefile:
-
-```bash
-export PDM_MULTIRUN_USE_VENVS = 1 # Uncomment this line to enable venvs when using multirun
-```
-
-With this option, the `scripts/setup.sh` script 
-will create named venvs (`name=3.xx`) 
-in your `venv.location` location (from pdm).
-
 If you don't have the `make` command,
 you can use `bash scripts/setup.sh` directly,
 or even just `pdm install`
 if you don't plan on using multiple Python versions.
+
+This will install the project's dependencies in `__pypackages__`:
+one folder per chosen Python version.
+The chosen Python versions are defined in the Makefile.
+If you would like to use *virtual environments (venvs)* instead,
+set the PDM configuration item `python.use_venv` to true:
+
+```bash
+pdm config --local python.use_venv
+```
+
+Remove the `--local` flag to enable using venvs for all your local projects.
+
+When venvs are enabled, the setup script will create named venvs (`name=3.xx`) 
+in your `venv.location` directory (PDM configuration).
 
 Now you can start writing and editing code in `src/your_package`.
 

--- a/project/Makefile.jinja
+++ b/project/Makefile.jinja
@@ -2,6 +2,7 @@
 SHELL := bash
 DUTY := $(if $(VIRTUAL_ENV),,pdm run) duty
 export PDM_MULTIRUN_VERSIONS ?= 3.8 3.9 3.10 3.11 3.12
+export PDM_MULTIRUN_USE_VENVS ?= $(shell grep -q 'use_venv = true' pdm.toml && echo 1 || echo 0)
 
 args = $(foreach a,$($(subst -,_,$1)_args),$(if $(value $a),$a="$($a)"))
 check_quality_args = files

--- a/project/Makefile.jinja
+++ b/project/Makefile.jinja
@@ -2,6 +2,7 @@
 SHELL := bash
 DUTY := $(if $(VIRTUAL_ENV),,pdm run) duty
 export PDM_MULTIRUN_VERSIONS ?= 3.8 3.9 3.10 3.11 3.12
+#export PDM_MULTIRUN_USE_VENVS = 1 # Uncomment this line to enable venvs when using multirun
 
 args = $(foreach a,$($(subst -,_,$1)_args),$(if $(value $a),$a="$($a)"))
 check_quality_args = files

--- a/project/Makefile.jinja
+++ b/project/Makefile.jinja
@@ -2,7 +2,6 @@
 SHELL := bash
 DUTY := $(if $(VIRTUAL_ENV),,pdm run) duty
 export PDM_MULTIRUN_VERSIONS ?= 3.8 3.9 3.10 3.11 3.12
-#export PDM_MULTIRUN_USE_VENVS = 1 # Uncomment this line to enable venvs when using multirun
 
 args = $(foreach a,$($(subst -,_,$1)_args),$(if $(value $a),$a="$($a)"))
 check_quality_args = files

--- a/project/Makefile.jinja
+++ b/project/Makefile.jinja
@@ -2,7 +2,7 @@
 SHELL := bash
 DUTY := $(if $(VIRTUAL_ENV),,pdm run) duty
 export PDM_MULTIRUN_VERSIONS ?= 3.8 3.9 3.10 3.11 3.12
-export PDM_MULTIRUN_USE_VENVS ?= $(shell grep -q 'use_venv = true' pdm.toml && echo 1 || echo 0)
+export PDM_MULTIRUN_USE_VENVS ?= $(if $(shell pdm config python.use_venv | grep True),1,0)
 
 args = $(foreach a,$($(subst -,_,$1)_args),$(if $(value $a),$a="$($a)"))
 check_quality_args = files

--- a/project/scripts/setup.sh
+++ b/project/scripts/setup.sh
@@ -12,8 +12,7 @@ if ! pdm self list 2>/dev/null | grep -q pdm-multirun; then
 fi
 
 if [ -n "${PDM_MULTIRUN_VERSIONS}" ]; then
-    if [ "$(pdm config --local python.use_venv)" = "True" ]; then
-        export PDM_MULTIRUN_USE_VENVS=1
+    if [ "${PDM_MULTIRUN_USE_VENVS}" -eq "1" ]; then
         for version in ${PDM_MULTIRUN_VERSIONS}; do
             if ! pdm venv --path "${version}" &>/dev/null; then
                 pdm venv create --name "${version}" "${version}"

--- a/project/scripts/setup.sh
+++ b/project/scripts/setup.sh
@@ -12,10 +12,11 @@ if ! pdm self list 2>/dev/null | grep -q pdm-multirun; then
 fi
 
 if [ -n "${PDM_MULTIRUN_VERSIONS}" ]; then
-    if [ "${PDM_MULTIRUN_USE_VENVS}" = "1" ]; then
-        for version in $PDM_MULTIRUN_VERSIONS; do
-            if ! pdm venv --path $version &>/dev/null; then # Skip if venv is already existing.
-                pdm venv create --name $version $version
+    if [ "$(pdm config --local python.use_venv)" = "True" ]; then
+        export PDM_MULTIRUN_USE_VENVS=1
+        for version in ${PDM_MULTIRUN_VERSIONS}; do
+            if ! pdm venv --path "${version}" &>/dev/null; then
+                pdm venv create --name "${version}" "${version}"
             fi
         done
     fi

--- a/project/scripts/setup.sh
+++ b/project/scripts/setup.sh
@@ -12,6 +12,13 @@ if ! pdm self list 2>/dev/null | grep -q pdm-multirun; then
 fi
 
 if [ -n "${PDM_MULTIRUN_VERSIONS}" ]; then
+    if [ "${PDM_MULTIRUN_USE_VENVS}" = "1" ]; then
+        for version in $PDM_MULTIRUN_VERSIONS; do
+            if ! pdm venv --path $version &>/dev/null; then # Skip if venv is already existing.
+                pdm venv create --name $version $version
+            fi
+        done
+    fi
     pdm multirun -v pdm install -G:all
 else
     pdm install -G:all


### PR DESCRIPTION
Reference: pawamoy/pdm-multirun#10

Adding the handling of `PDM_MULTIRUN_USE_VENVS` in `script/setup.ph` and giving the option for the `Makefile`.

- Changing `setup.ph` to check for the environment variable and if set to `1` creating named venvs (e.g. 3.11, exactly as the version specifier. One could change this if another behavoir is preferred, no strong opinion here)
- Adding a comment to the Makefile, that can be uncommented.
- Updating docs (couldn't check docs, `mkdocs` `callouts` didn't worked for me.

Not sure on the documentation, not too experienced there. Please check and change to your likeing.