### PR TITLE
chore: do not allow release without version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ changelog:
 
 release:
 ifndef version
-$(error version is not set) # If no version is provided, throw an error.
+$(error version is not set)
 endif
 	@git add CHANGELOG.md
 	@git commit -m "docs: Update changelog for version $(version)"

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ changelog:
 	@git-changelog -Tio CHANGELOG.md -Bauto -c angular
 
 release:
+	ifndef version
+		$(error version is not set) # If no version is provided, throw an error.
+	endif
 	@git add CHANGELOG.md
 	@git commit -m "docs: Update changelog for version $(version)"
 	@git tag $(version)

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ changelog:
 	@git-changelog -Tio CHANGELOG.md -Bauto -c angular
 
 release:
-	ifndef version
-		$(error version is not set) # If no version is provided, throw an error.
-	endif
+ifndef version
+$(error version is not set) # If no version is provided, throw an error.
+endif
 	@git add CHANGELOG.md
 	@git commit -m "docs: Update changelog for version $(version)"
 	@git tag $(version)


### PR DESCRIPTION
The change checks if the `version` environment variable is provided for a release.

This was something I messed up the first time, I tried to release a new version in my fork. If this is an unwanted change, just reject the PR. 😃 